### PR TITLE
Add Id.nextInt().

### DIFF
--- a/src/main/java/org/n3r/idworker/Id.java
+++ b/src/main/java/org/n3r/idworker/Id.java
@@ -5,6 +5,7 @@ import org.n3r.idworker.strategy.DefaultWorkerIdStrategy;
 public class Id {
     private static WorkerIdStrategy workerIdStrategy;
     private static IdWorker idWorker;
+    private static IdWorkerInt idWorkerInt;
 
     static {
         configure(DefaultWorkerIdStrategy.instance);
@@ -16,11 +17,17 @@ public class Id {
         if (workerIdStrategy != null) workerIdStrategy.release();
         workerIdStrategy = custom;
         workerIdStrategy.initialize();
-        idWorker = new IdWorker(workerIdStrategy.availableWorkerId());
+        long availableWorkerId = workerIdStrategy.availableWorkerId();
+        idWorker = new IdWorker(availableWorkerId);
+        idWorkerInt = new IdWorkerInt(availableWorkerId & (~(-1L << 5L)));
     }
 
     public static long next() {
         return idWorker.nextId();
+    }
+
+    public static int nextInt() {
+        return idWorkerInt.nextIdInt();
     }
 
     public static long getWorkerId() {

--- a/src/main/java/org/n3r/idworker/IdWorker.java
+++ b/src/main/java/org/n3r/idworker/IdWorker.java
@@ -8,13 +8,13 @@ import java.security.SecureRandom;
 public class IdWorker {
     protected long epoch = 1387886498127L; // 2013-12-24 20:01:38.127
 
-    protected long workerIdBits = 10L;
-    protected long maxWorkerId = -1L ^ (-1L << workerIdBits);
-    protected long sequenceBits = 11L;
+    protected long workerIdBits;
+    protected long maxWorkerId;
+    protected long sequenceBits;
 
-    protected long workerIdShift = sequenceBits;
-    protected long timestampLeftShift = sequenceBits + workerIdBits;
-    protected long sequenceMask = -1L ^ (-1L << sequenceBits);
+    protected long workerIdShift;
+    protected long timestampLeftShift;
+    protected long sequenceMask;
 
     protected long lastMillis = -1L;
 
@@ -23,6 +23,14 @@ public class IdWorker {
     protected Logger logger = LoggerFactory.getLogger(IdWorker.class);
 
     public IdWorker(long workerId) {
+        workerIdBits = workerIdBits();
+        maxWorkerId = -1L ^ (-1L << workerIdBits);
+        sequenceBits = sequenceBits();
+
+        workerIdShift = sequenceBits;
+        timestampLeftShift = sequenceBits + workerIdBits;
+        sequenceMask = -1L ^ (-1L << sequenceBits);
+
         this.workerId = checkWorkerId(workerId);
 
         logger.debug("worker starting. timestamp left shift {}, worker id bits {}, sequence bits {}, worker id {}",
@@ -31,6 +39,14 @@ public class IdWorker {
 
     public long getEpoch() {
         return epoch;
+    }
+
+    public long workerIdBits() {
+        return 10L;
+    }
+
+    public long sequenceBits() {
+        return 11L;
     }
 
     private long checkWorkerId(long workerId) {

--- a/src/main/java/org/n3r/idworker/IdWorkerInt.java
+++ b/src/main/java/org/n3r/idworker/IdWorkerInt.java
@@ -1,0 +1,23 @@
+package org.n3r.idworker;
+
+public class IdWorkerInt extends IdWorker {
+
+    public IdWorkerInt(long workerId) {
+        super(workerId & (~(-1L << 5L)));
+    }
+
+    @Override
+    public long workerIdBits() {
+        return 5L;
+    }
+
+    @Override
+    public long sequenceBits() {
+        return 5L;
+    }
+
+    public synchronized int nextIdInt() {
+        int nextIdInt = (int) super.nextId();
+        return (nextIdInt << 1) >>> 1;
+    }
+}

--- a/src/test/java/org/n3r/idworker/IdWorkerIntTest.java
+++ b/src/test/java/org/n3r/idworker/IdWorkerIntTest.java
@@ -1,0 +1,45 @@
+package org.n3r.idworker;
+
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class IdWorkerIntTest {
+
+    @Test
+    public void onlyUniqueIds() {
+        IdWorkerInt worker = new IdWorkerInt(31);
+        Set<Integer> set = new HashSet<>();
+        int n = 2000000;
+        for (int i = 0; i < 2000000; ++i) {
+            int id = worker.nextIdInt();
+            if (set.contains(id)) {
+                System.out.println(id);
+            } else {
+                set.add(id);
+            }
+        }
+
+        assertThat(set.size(), is(n));
+    }
+
+    @Test
+    public void onlyUniqueIds2() {
+        Set<Integer> set = new HashSet<>();
+        int n = 2000000;
+        for (int i = 0; i < 2000000; ++i) {
+            int id = Id.nextInt();
+            if (set.contains(id)) {
+                System.out.println(id);
+            } else {
+                set.add(id);
+            }
+        }
+
+        assertThat(set.size(), is(n));
+    }
+}


### PR DESCRIPTION
增加返回正整型随机数方法, 参照Id.next()方法, 32位整型结果由3部分组成:
1. 21位由毫秒数产生的随机数, 最大值为2097152, 约为34.95分钟;
2. 5位work id, 最大值为32;
3. 5位自增序列, 即每毫秒可产生32个随机数.

因为在使用微信公众平台时, 需要生成带参数的临时二维码, 而微信API限制二维码参数值为32位非0整型, 无法直接使用Id.next()方法.
但是配合微信临时二维码的过期时间设置, 若使二维码在生成的随机参数发生碰撞前(即34.95分钟以内)失效, 则可以在保证参数随机的同时生成唯一的临时二维码.

现在, 在实现Id.nextInt()方法后, 业务逻辑如下:
1. 当需要生成关联某一业务实体的微信临时二维码时, 使用Id.nextInt()方法生成随机数, 在业务系统内映射目标业务实体;
2. 调用微信API生成有效时间为30分钟的二维码交由业务系统前台展示;
2. 微信用户扫描二维码后, 业务系统后台收到微信扫码事件通知, 从通知内取出二维码参数, 以此参数寻找到系统内映射的目标业务实体, 并开始之后的业务逻辑.